### PR TITLE
Remove double state

### DIFF
--- a/slides/5_1-rust-for-web.md
+++ b/slides/5_1-rust-for-web.md
@@ -78,7 +78,7 @@ layout: default
 
 ```rust
 /// A very long type name warrants a type alias
-type AppState = State<Arc<Mutex<Vec<String>>>>;
+type AppState = Arc<Mutex<Vec<String>>>;
 
 async fn handler(
     Path(name): Path<String>,


### PR DESCRIPTION
`State<AppState>` used to be `State<State<Arc<Mutex<Vec<String>>>>>`, which probably does not make sense