### PR TITLE
Add test cases for "unterminated" sequences

### DIFF
--- a/exercises/7-rust-for-data-science/1-rust-from-python/test_decoding.py
+++ b/exercises/7-rust-for-data-science/1-rust-from-python/test_decoding.py
@@ -27,6 +27,45 @@ def test_orf_decoding():
     assert orf.decoded == "AGIVGTSLRLIIRAELGQPGTLIGNDQIYNVVVTAHAFVIIFFMVIPIIIGGFGN*"
 
 
+def test_orf_decoding_without_stop():
+    seq = (
+        "GCTGGGATAGTAGGCACATCCTTAAGATTAATTATCCGAGCCGAACTAGGTC"
+        "AACCAGGAACTCTTATTGGTAATGATCAAATCTATAATGTAGTAGTTACAGC"
+        "TCACGCTTTTGTAATAATTTTTTTTATGGTCATACCTATTATAATTGGAGGA"
+        "TTCGGTAAT"
+    )
+
+    orf = decode_orf(Sequence(seq), 0)
+
+    assert orf.start == 0
+    assert orf.end == len(seq)
+    assert orf.decoded == "AGIVGTSLRLIIRAELGQPGTLIGNDQIYNVVVTAHAFVIIFFMVIPIIIGGFGN"
+
+
+def test_orf_decoding_without_stop_and_excess_base():
+    with pytest.raises(ValueError):
+        decode_orf(Sequence("G"), 0)
+
+    with pytest.raises(ValueError):
+        decode_orf(Sequence("GT"), 0)
+
+    orf = decode_orf(Sequence("GTC"), 0)
+    assert orf.start == 0
+    assert orf.end == 3
+    assert orf.decoded == "V"
+
+    with pytest.raises(ValueError):
+        decode_orf(Sequence("GTCG"), 0)
+
+    with pytest.raises(ValueError):
+        decode_orf(Sequence("GTCGG"), 0)
+
+    orf = decode_orf(Sequence("GTCGGG"), 0)
+    assert orf.start == 0
+    assert orf.end == 6
+    assert orf.decoded == "VG"
+
+
 def test_all_orf_decoding_small():
     seq = "ATGGCTTAAATGAATTAG"
 


### PR DESCRIPTION
Adds two test cases helping to check future Rust ports of `decode_orf`: sequences without a stop codon and excess bases.