### PR TITLE
Revert "Reduce dependabot noise"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    versioning-strategy: increase-if-necessary
     directories:
       - "/exercises/1-course-introduction/1-introduction/1-setup-your-installation"
       - "/exercises/1-course-introduction/1-introduction/2-embedded"


### PR DESCRIPTION
Reverts tweedegolf/rust-training#193

Apparently that option does not work with `cargo` dependencies...