### PR TITLE
updated broken links

### DIFF
--- a/book/src/async-rust-python.md
+++ b/book/src/async-rust-python.md
@@ -70,7 +70,7 @@ Now, let's say we have a stream of JSON. Could be from someone on the internet o
 
 This JSON is an array of objects that each represent the following:
 - `lhs`: a matrix with `m` rows and `n` columns. `m` can be derived from `n` and the length of `d`. In this case `m = len / n = 12 / 3 = 4`.
-- `op`: a sequence of operations that need to take place given `lhs` and, if the operation takes two operands, its `rhs` field. `x` corresponds to the operation that should be executed, and should more or less correspond to the methods provided on [nalgebra](https://nalgebra.org/)'s [Matrix](https://docs.rs/nalgebra/0.32.4/nalgebra/base/struct.Matrix.html) type. In this case, the [`Matrix::dot`](https://docs.rs/nalgebra/0.32.4/nalgebra/base/struct.Matrix.html#dotscalar-product) method should be run, which, for probably good reason, is describead as 'the dot product between two vectors or matrices (seen as vectors)'.
+- `op`: a sequence of operations that need to take place given `lhs` and, if the operation takes two operands, its `rhs` field. `x` corresponds to the operation that should be executed, and should more or less correspond to the methods provided on [nalgebra](https://nalgebra.rs/)'s [Matrix](https://docs.rs/nalgebra/0.32.4/nalgebra/base/struct.Matrix.html) type. In this case, the [`Matrix::dot`](https://docs.rs/nalgebra/0.32.4/nalgebra/base/struct.Matrix.html#dotscalar-product) method should be run, which, for probably good reason, is describead as 'the dot product between two vectors or matrices (seen as vectors)'.
 
 Our library should streamingly deserialize each incoming object from an [`asyncio`](https://docs.python.org/3/library/asyncio.html) stream of bytes, apply the given operation, and pass on the result.
 

--- a/slides/4_3-asynchronous-multitasking.md
+++ b/slides/4_3-asynchronous-multitasking.md
@@ -844,7 +844,7 @@ pub trait Future {
 - `&mut self` &rarr; `Pin<&mut Self>`: makes `Self` immovable
 - `wake: fn()` &rarr; `cx: &mut Context<'_>`: contains a `Waker`
 
-*More on `Pin<&mut Self>` in the [Rust async book](https://rust-lang.github.io/async-book/04_pinning/01_chapter.html)*
+*More on `Pin<&mut Self>` in the [Rust async book](https://rust-lang.github.io/async-book/part-reference/pinning.html)*
 </div>
 </v-click>
 

--- a/slides/8_1-embedded-ecosystem.md
+++ b/slides/8_1-embedded-ecosystem.md
@@ -70,7 +70,7 @@ layout: with-footer
     </td>
     <td></td>
     <td><center><img src="https://doc.rust-lang.org/1.85.0/cargo/images/Cargo-Logo-Small.png" width="75" height="75"></center></td>
-    <td><center><img src="https://probe.rs/images/banner.svg" width="75" height="75"></center></td>
+    <td><center><img src="https://raw.githubusercontent.com/probe-rs/webpage/044a6bc2d87cecb1784d0def1f460a3dfbc062eb/src/images/banner.svg" width="75" height="75"></center></td>
 </tr>
 </table>
 


### PR DESCRIPTION
From [this report](https://github.com/tweedegolf/rust-training/issues/219), updated 3 links, 2 worked fine (did not timeout for me), 1 is still TODO:
https://training.tweede.golf/slides/4_2-parallel-multitasking/#/16 (The 'Photo Ferris' no longer exist [here](https://arctype.com/blog/content/images/size/w1750/2021/02/deadlock.jpeg), TODO is find alternative)