### PR TITLE
Disable scheduled link checking

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -3,8 +3,6 @@ name: Links
 on:
   repository_dispatch:
   workflow_dispatch:
-  schedule:
-    - cron: "00 18 * * *"
   push:
     branches:
       - main


### PR DESCRIPTION
GitHub Action runners seem to be rejected by a lot of sites. So this causes to many false positives at the moment.